### PR TITLE
fix ci & add publish action, add `@spell` to comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm install
+      - run: npm test
+
+  publish-npm:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm install
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+  publish-crates:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Ungrammar grammar for tree-sitter"
 version = "0.0.1"
 keywords = ["incremental", "parsing", "ungrammar"]
 categories = ["parsing", "text-editors"]
-repository = "https://github.com/tree-sitter/tree-sitter-ungrammar"
+repository = "https://github.com/Philipp-M/tree-sitter-ungrammar"
 edition = "2021"
 license = "MIT"
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+(comment) @comment @spell
 
 (definition) @keyword
 


### PR DESCRIPTION
This requires two action secrets set in the repo settings. Unfortunately I cannot add/access the repo settings, any chance you can add that for me? Any secrets added cannot be seen by anyone after being added, so no need to worry about tokens/secrets being leaked among ourselves. I have published 0.0.1 manually already, but I'd like to tag this commit as v0.0.1 once we set up the secret.

Thanks!
Amaan